### PR TITLE
💄[style] 보영님의 피드백을 바탕으로 디테일 문의/리뷰 팝업관련 수정 (feat/#96)

### DIFF
--- a/src/components/ProductDetailPopUp/ProductDetailPopUp.module.scss
+++ b/src/components/ProductDetailPopUp/ProductDetailPopUp.module.scss
@@ -85,9 +85,9 @@
   }
   textarea {
     width: 629px;
-    height: 198px;
+    height: 200px;
     color: var(--gray-300);
-    display: inline-block;
+    display: block;
     border: 0px;
     padding: 16px;
     resize: none;

--- a/src/components/ProductDetailPopUp/ProductDetailPopUpLayout.module.scss
+++ b/src/components/ProductDetailPopUp/ProductDetailPopUpLayout.module.scss
@@ -3,11 +3,11 @@
   /*------portal 띄우기------*/
   position: absolute;
   top: 50%;
+  left: 50%;
   bottom: 0;
   right: 0;
-  left: 50%;
-  transform: translate(-43.5%, -50%);
-  // transform: translate(0, -50%);
-  margin: 0 auto;
+  transform: translate(-50%, -50%);
+  width: 793px;
   /*------/portal 띄우기------*/
 }
+

--- a/src/components/ProductDetailPopUp/Secret/Secret.jsx
+++ b/src/components/ProductDetailPopUp/Secret/Secret.jsx
@@ -5,8 +5,9 @@ export function Secret() {
     <>
       <div className={styles.secretCheckBox}>
         <input id="isSecret" name="checker" role="tab" tabIndex="0" type="checkbox" />
-        <label htmlFor="isSecret"></label>
-        <span>비밀글로 문의하기</span>
+        <label htmlFor="isSecret">
+          <span>비밀글로 문의하기</span>
+        </label>
       </div>
     </>
   );

--- a/src/components/ProductDetailPopUp/Secret/Secret.module.scss
+++ b/src/components/ProductDetailPopUp/Secret/Secret.module.scss
@@ -7,8 +7,8 @@
   gap: 8px;
   margin-left: 101px;
   input[type="checkbox"]+label {
-    display: inline-block;
-    width: 24px;
+    display: flex;
+    align-items: center;
     height: 24px;
     background: url('../../../assets/product-detail/secret-checked-false.svg') no-repeat 0 0px / contain;
   }
@@ -22,7 +22,8 @@
     font-weight: 400;
     font-size: 12.003px;
     line-height: 160%;
-    width: 87px;
-    height: 19px;
+    display: inline-block;
+    line-height: 24px;
+    padding-left: 32px;
   }
 }


### PR DESCRIPTION
### 피드백 받은 부분
1. 팝업창의 위치 조절 (ProductDetailPopUpLayout.module.scss 수정)
   - 팝업창이 화면 정가운데에 오지 않았던 점을 해결함
2. 문의팝업창의 경우, '비밀글로 문의하기'를 설정할 수 있는데, 체크박스와 텍스트가 연결이 안되어있었음
   - span태그를 label태그 안에 배치함으로써, 사용자가 텍스트를 클릭해도 체크박스의 상태를 조절할 수 있게 만듬
3. textarea영역에 초점에 갈때 아래쪽에 약간의 빈틈이 생기는 문제
   - 기존에는 display: inline-block으로 설정했었는데, inline특성상 약간의 빈틈이 발생했었음. block으로 바꾸니 해결.