### PR TITLE
🐛 [fix] 팝업창 ProductDetailPopUpLayout.module.scss에서, bottom과 right 삭제 #96

### DIFF
--- a/src/components/ProductDetailPopUp/ProductDetailPopUpLayout.module.scss
+++ b/src/components/ProductDetailPopUp/ProductDetailPopUpLayout.module.scss
@@ -4,8 +4,6 @@
   position: fixed;
   top: 50%;
   left: 50%;
-  bottom: 0;
-  right: 0;
   transform: translate(-50%, -50%);
   width: 793px;
   /*------/portal 띄우기------*/


### PR DESCRIPTION
```
.productDetailPopUpLayout {
  z-index: 1200;
  /*------portal 띄우기------*/
  position: fixed;
  top: 50%;
  left: 50%;
  transform: translate(-50%, -50%);
  width: 793px;
  /*------/portal 띄우기------*/
}
```
위의 코드는 수정 이후의 코드입니다.
이전에는 
```
  right: 0;
  bottom: 0;
```
을 함께 넣어줬었는데,
그러한 이유로, 화면 정가운데에 팝업창이 위치하지 못했었습니다.
따라서, right와 bottom값을 삭제했습니다.